### PR TITLE
Rit-37-add-configuration-for-food-consumption-multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supports multiplayer.
 
 **Beta Software:** Please back up your savegames before use. The mod is fully functional but still in beta testing.
 
-As of version 0.11.0.0
+As of version 0.12.0.0
 You can:
 - Add custom food groups to animals and custom ingredients to mixtures/recipes
 - Disable unwanted food groups or ingredients

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can:
 - Change which crops belong to each food group (fillTypes)
 - Modify mixed feed recipes and ingredient proportions
 - Customize TMR/forage recipe compositions and ranges
+- Control animal food consumption speed with a multiplier
 
 You **cannot**:
 - Cannot delete or add new animal types (only modify existing animals like COW, PIG, CHICKEN, SHEEP, HORSE)
@@ -35,6 +36,7 @@ Documentation, source code and issue tracker at https://github.com/rittermod/FS2
 - **Custom Crop Assignments**: Add or remove crops from any food group (e.g., add oat to chicken feed, allow cows to eat alfalfa silage)
 - **Mixed Feed Customization**: Adjust ingredient proportions and crop types for mixed feeds like pig food
 - **Recipe Control**: Customize recipes with precise min/max percentage ranges for each ingredient
+- **Consumption Speed Control**: Adjust how fast animals consume food with a configurable multiplier (0.01x to 100x)
 - **Automatic Normalization**: Remaining ingredients automatically adjust when you disable or modify items
 - **Schema-Validated Configuration**: Uses the game's built-in AnimalFoodSystem schema for robust, error-checked XML handling
 - **Intelligent Merging**: Your XML overrides customizations while automatically adding new content from mods or game updates
@@ -171,6 +173,28 @@ Controls TMR/Forage recipes for mixing wagons.
 - Ratios are automatically normalized based on your min/max ranges
 - When you disable an ingredient, it's completely removed from the TMR mixer UI
 - You cannot disable entire recipes, only individual ingredients
+
+### Consumption Multiplier Section
+
+Control how fast animals consume their food supply. This feature is **disabled by default** (opt-in).
+
+```xml
+<consumptionMultiplier>
+    <global multiplier="1.0" disabled="true"/>
+</consumptionMultiplier>
+```
+
+**What You Can Change:**
+- `multiplier`: Food consumption speed (0.01-100)
+  - `0.5` = Animals eat half as fast (food lasts longer)
+  - `1.0` = Normal speed (default)
+  - `2.0` = Animals eat twice as fast (food depletes faster)
+- `disabled`: Set to `"false"` to enable this feature
+
+**Notes:**
+- This feature only affects consumption **rate**, not food effectiveness (use `productionWeight` for that)
+- Automatically disabled if incompatible mods are detected (e.g., FS25_RealisticLivestock)
+- Server-authoritative in multiplayer: multiplier is applied on server, clients see the results
 
 ## Practical Examples
 
@@ -341,6 +365,30 @@ Want to add a custom food group? Remember the 5-entry limit! COW has 4 vanilla f
 
 Same principle applies to mixtures and recipes - keep active entries ≤ 5.
 
+### Speed Up Food Consumption (Testing/Fast-Forward)
+
+Enable the consumption multiplier to make animals eat faster:
+
+```xml
+<consumptionMultiplier>
+    <global multiplier="2.0" disabled="false"/>
+</consumptionMultiplier>
+```
+
+Animals now consume food twice as fast. Useful for testing animal systems or speeding up gameplay.
+
+### Slow Down Food Consumption (Realism/Easy Mode)
+
+Reduce consumption rate to make food last longer:
+
+```xml
+<consumptionMultiplier>
+    <global multiplier="0.5" disabled="false"/>
+</consumptionMultiplier>
+```
+
+Animals eat half as fast. Food supplies last twice as long.
+
 ## How It Works
 
 The mod integrates with Farming Simulator's animal food system through several mechanisms:
@@ -384,4 +432,11 @@ The merging system should handle most conflicts automatically. If you have issue
 - The last-loaded mod's XML values will take precedence
 - Check if other mods modify the same animal food values
 - Try loading this mod last (rename to start with "zzz" if needed)
+
+### Consumption Multiplier Not Working
+
+- Make sure `disabled="false"` is set (the feature is disabled by default)
+- Check the game log for "Incompatible mod detected" warning - the multiplier is automatically disabled when conflicting mods like FS25_RealisticLivestock are active
+- Verify the multiplier value is between 0.01 and 100
+- In multiplayer, the multiplier only applies on the server - clients see the results but don't apply the hook themselves
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="100">
     <author>Ritter</author>
-    <version>0.11.0.0</version>
+    <version>0.12.0.0</version>
 
     <title>
         <en>Adjust Animal Food</en>
@@ -22,12 +22,14 @@ Customize aspects of animal feeding without modifying map files:
 - Change which crops belong to each food group (fillTypes)
 - Modify mixed feed recipes and ingredient proportions
 - Customize TMR/forage recipe compositions and ranges
+- Control animal food consumption speed with a multiplier (0.01x to 100x)
 
 Limitations (what this mod CANNOT do):
 - Cannot disable the Grass food group - causes game hang. You can change its weights.
 - Cannot delete or add new animal types (only modify existing animals like COW, PIG, CHICKEN, SHEEP, HORSE)
 - Cannot delete or add new mixtures/recipes (only modify existing ones like PIGFOOD, FORAGE)
 - Cannot change internal names or titles (these are used for matching only)
+- Consumption multiplier auto-disables when known incompatible mods are detected (e.g., FS25_RealisticLivestock)
 
 Usage:
 - Configuration file (aaf_AnimalFood.xml) is automatically created in your savegame folder on first game save.
@@ -38,6 +40,12 @@ Usage:
 Documentation, source code and issue tracker at https://github.com/rittermod/FS25_AdjustAnimalFood
 
 Changelog:
+0.12.0.0:
+- Added food consumption multiplier (0.01x to 100x) to speed up or slow down how fast animals eat
+- Consumption multiplier is opt-in (disabled by default)
+- Auto-disables consumption multiplier when known incompatible mods detected
+- Bounds validation with warning and clamping for invalid multiplier values
+
 0.11.0.0:
 - Change animal feeding behavior between SERIAL and PARALLEL consumption modes
 - Reorganized XML documentation with brief readme and comprehensive guide at end

--- a/scripts/modules/RmAafDataMerger.lua
+++ b/scripts/modules/RmAafDataMerger.lua
@@ -243,6 +243,24 @@ function RmAafDataMerger:mergeData(xmlData, gameData, preserveAllXmlOnly)
     merged.mixtures = mergeMixtures(xmlData.mixtures, gameData.mixtures, preserveAllXmlOnly)
     merged.recipes = mergeRecipes(xmlData.recipes, gameData.recipes, preserveAllXmlOnly)
 
+    -- Merge consumption multiplier settings (XML takes precedence, or use defaults)
+    if xmlData.consumptionMultiplier then
+        merged.consumptionMultiplier = {
+            multiplier = xmlData.consumptionMultiplier.multiplier or 1.0,
+            disabled = xmlData.consumptionMultiplier.disabled
+        }
+        -- Handle nil disabled (treat as true/disabled by default)
+        if merged.consumptionMultiplier.disabled == nil then
+            merged.consumptionMultiplier.disabled = true
+        end
+    else
+        -- No consumption multiplier in XML - use defaults (disabled)
+        merged.consumptionMultiplier = {
+            multiplier = 1.0,
+            disabled = true
+        }
+    end
+
     RmLogging.logInfo("Merged to %d animals, %d mixtures, %d recipes",
         #merged.animals, #merged.mixtures, #merged.recipes)
 


### PR DESCRIPTION
0.12.0.0:
- Added food consumption multiplier (0.01x to 100x) to speed up or slow down how fast animals eat
- Consumption multiplier is opt-in (disabled by default)
- Auto-disables consumption multiplier when known incompatible mods detected
- Bounds validation with warning and clamping for invalid multiplier values

Closes #5